### PR TITLE
Update Deagle.dec

### DIFF
--- a/actors/Weapons/Slot2/Deagle.dec
+++ b/actors/Weapons/Slot2/Deagle.dec
@@ -239,6 +239,7 @@ ACTOR Deagle : PB_Weapon
 				A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0);
 				A_FireCustomMissile("GunFireSmoke", 0, 0, 0, 0, 0, 0);
 				A_FireCustomMissile("YellowFlareSpawn",0,0,0,0);
+				A_FireCustomMissile("Mp40CaseSpawn", 0,0,0,-3);
 				A_Takeinventory("DeagleAmmo",1);
 				A_ZoomFactor(0.96);
 				


### PR DESCRIPTION
Added shell ejection to un-aimed fire of the Desert Eagle with a vertical offset of -3 to appear closer to shell originating from the chamber. This was noticed by myself when I ended up getting the upgrade and playing around with it a bit, there was shell ejection upon firing when aimed, but not for the default fire state. 